### PR TITLE
Rcd household delete

### DIFF
--- a/01_Db_Create.sql.sql
+++ b/01_Db_Create.sql.sql
@@ -10,9 +10,9 @@ GO
 DROP TABLE IF EXISTS [ListItem];
 DROP TABLE IF EXISTS [Purchase];
 DROP TABLE IF EXISTS [ShoppingList];
+DROP TABLE IF EXISTS [HouseholdUser];
 DROP TABLE IF EXISTS [Household];
 DROP TABLE IF EXISTS [UserType];
-DROP TABLE IF EXISTS [HouseholdUser];
 DROP TABLE IF EXISTS [User];
 GO
 
@@ -45,7 +45,7 @@ CREATE TABLE [ShoppingList] (
   [Name] nvarchar(50) NOT NULL,
   [DateCreated] datetime NOT NULL,
 
-  CONSTRAINT [FK_ShoppingList_Household] FOREIGN KEY ([HouseholdId]) REFERENCES [Household] ([Id]) 
+  CONSTRAINT [FK_ShoppingList_Household] FOREIGN KEY ([HouseholdId]) REFERENCES [Household] ([Id]) ON DELETE CASCADE
 )
 GO
 
@@ -57,8 +57,8 @@ CREATE TABLE [Purchase] (
   [PurchaseDate] datetime NOT NULL,
   [TotalCost] decimal NOT NULL,
 
-  CONSTRAINT [FK_Purchase_ShoppingList] FOREIGN KEY ([ShoppingListId]) REFERENCES [ShoppingList] ([Id]), 
-  CONSTRAINT [FK_Purchase_User] FOREIGN KEY ([UserId]) REFERENCES [User] ([Id]) 
+  CONSTRAINT [FK_Purchase_ShoppingList] FOREIGN KEY ([ShoppingListId]) REFERENCES [ShoppingList] ([Id]) ON DELETE CASCADE, 
+  CONSTRAINT [FK_Purchase_User] FOREIGN KEY ([UserId]) REFERENCES [User] ([Id]) ON DELETE CASCADE
 )
 GO
 
@@ -68,7 +68,7 @@ CREATE TABLE [ListItem] (
   [Name] nvarchar(50) NOT NULL,
   [IsChecked] bit NOT NULL DEFAULT 0,
 
-  CONSTRAINT [FK_ListItem_ShoppingList] FOREIGN KEY ([ShoppingListId]) REFERENCES [ShoppingList] ([Id])
+  CONSTRAINT [FK_ListItem_ShoppingList] FOREIGN KEY ([ShoppingListId]) REFERENCES [ShoppingList] ([Id]) ON DELETE CASCADE
 )
 GO
 
@@ -79,8 +79,8 @@ CREATE TABLE [HouseholdUser] (
   [UserTypeId] integer NOT NULL,
   [IsAccepted] bit NOT NULL DEFAULT 0,
 
-  CONSTRAINT [FK_HouseholdUser_Household] FOREIGN KEY ([HouseholdId]) REFERENCES [Household] ([Id]),
-  CONSTRAINT [FK_HouseholdUser_User] FOREIGN KEY ([UserId]) REFERENCES [User] ([Id]),
+  CONSTRAINT [FK_HouseholdUser_Household] FOREIGN KEY ([HouseholdId]) REFERENCES [Household] ([Id]) ON DELETE CASCADE,
+  CONSTRAINT [FK_HouseholdUser_User] FOREIGN KEY ([UserId]) REFERENCES [User] ([Id]) ON DELETE CASCADE,
   CONSTRAINT [FK_HouseholdUser_UserType] FOREIGN KEY ([UserTypeId]) REFERENCES [UserType] ([Id])
 )
 GO

--- a/GroSharies/Controllers/HouseholdController.cs
+++ b/GroSharies/Controllers/HouseholdController.cs
@@ -92,9 +92,12 @@ namespace GroSharies.Controllers
             var user = GetCurrentUser();
             if (user == null) return NotFound();
 
+            // Check to make sure that the current user is an admin of the selected household
+            var householdUser = _householdUserRepository.GetHouseholdUser(householdId, user.Id);
+            if (householdUser.UserTypeId != 1) return Unauthorized();
 
-
-            _householdRepository.Delete(householdId, shoppingListId);
+            _householdRepository.Delete(householdId);
+            return NoContent();
         }
 
         // Retrieves the current user object by using the provided firebaseId

--- a/GroSharies/Controllers/HouseholdController.cs
+++ b/GroSharies/Controllers/HouseholdController.cs
@@ -38,7 +38,7 @@ namespace GroSharies.Controllers
         }
 
         [HttpGet("{householdId}")]
-        public IActionResult GetById(int householdId) 
+        public IActionResult GetById(int householdId)
         {
             var user = GetCurrentUser();
             if (user == null) return NotFound();
@@ -47,7 +47,7 @@ namespace GroSharies.Controllers
             var userHouseholds = _householdRepository.GetAllHouseholds(user.Id);
             if (!userHouseholds.Any(household => household.Id == householdId)) return Unauthorized();
 
-            var householdDetail = _householdRepository.GetById(householdId);          
+            var householdDetail = _householdRepository.GetById(householdId);
             return Ok(householdDetail);
         }
 
@@ -84,6 +84,17 @@ namespace GroSharies.Controllers
             _householdRepository.Update(household);
 
             return NoContent();
+        }
+
+        [HttpDelete("{householdId}")]
+        public IActionResult Delete(int householdId)
+        {
+            var user = GetCurrentUser();
+            if (user == null) return NotFound();
+
+
+
+            _householdRepository.Delete(householdId, shoppingListId);
         }
 
         // Retrieves the current user object by using the provided firebaseId

--- a/GroSharies/Repositories/HouseholdRepository.cs
+++ b/GroSharies/Repositories/HouseholdRepository.cs
@@ -136,5 +136,63 @@ namespace GroSharies.Repositories
                 }
             }
         }
+
+        public void Delete(int householdId, int shoppingListId)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+
+                // Delete ListItem rows related to the Household's ShoppingList(s)
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        DELETE ListItem
+                        WHERE ShoppingListId = @Id";
+
+                    DbUtils.AddParameter(cmd, "@Id", shoppingListId);
+                }
+
+                // Delete Purchase rows related to the Household's ShoppingList(s)
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        DELETE Purchase
+                        WHERE ShoppingListId = @Id";
+
+                    DbUtils.AddParameter(cmd, "@Id", shoppingListId);
+                }
+
+                // Delete ShoppingList rows related to the Household
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        DELETE ShoppingList
+                        WHERE HouseholdId = @Id";
+
+                    DbUtils.AddParameter(cmd, "@Id", householdId);
+                }
+
+                // Delete HouseholdUser rows related to the Household
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        DELETE HouseholdUser
+                        WHERE HouseholdId = @Id";
+
+                    DbUtils.AddParameter(cmd, "@Id", householdId);
+                }
+
+                // Finally, delete the Household
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        DELETE Household
+                        WHERE Id = @Id";
+
+                    DbUtils.AddParameter(cmd, "@Id", householdId);
+                }
+            }
+        }
     }
 }

--- a/GroSharies/Repositories/HouseholdRepository.cs
+++ b/GroSharies/Repositories/HouseholdRepository.cs
@@ -158,6 +158,7 @@ namespace GroSharies.Repositories
                         WHERE Id = @Id";
 
                     DbUtils.AddParameter(cmd, "@Id", householdId);
+                    cmd.ExecuteNonQuery();
                 }
             }
         }

--- a/GroSharies/Repositories/HouseholdRepository.cs
+++ b/GroSharies/Repositories/HouseholdRepository.cs
@@ -137,53 +137,20 @@ namespace GroSharies.Repositories
             }
         }
 
-        public void Delete(int householdId, int shoppingListId)
+        public void Delete(int householdId)
         {
             using (var conn = Connection)
             {
                 conn.Open();
 
-                // Delete ListItem rows related to the Household's ShoppingList(s)
-                using (var cmd = conn.CreateCommand())
-                {
-                    cmd.CommandText = @"
-                        DELETE ListItem
-                        WHERE ShoppingListId = @Id";
-
-                    DbUtils.AddParameter(cmd, "@Id", shoppingListId);
-                }
-
-                // Delete Purchase rows related to the Household's ShoppingList(s)
-                using (var cmd = conn.CreateCommand())
-                {
-                    cmd.CommandText = @"
-                        DELETE Purchase
-                        WHERE ShoppingListId = @Id";
-
-                    DbUtils.AddParameter(cmd, "@Id", shoppingListId);
-                }
-
-                // Delete ShoppingList rows related to the Household
-                using (var cmd = conn.CreateCommand())
-                {
-                    cmd.CommandText = @"
-                        DELETE ShoppingList
-                        WHERE HouseholdId = @Id";
-
-                    DbUtils.AddParameter(cmd, "@Id", householdId);
-                }
-
-                // Delete HouseholdUser rows related to the Household
-                using (var cmd = conn.CreateCommand())
-                {
-                    cmd.CommandText = @"
-                        DELETE HouseholdUser
-                        WHERE HouseholdId = @Id";
-
-                    DbUtils.AddParameter(cmd, "@Id", householdId);
-                }
-
-                // Finally, delete the Household
+                // Delete the specified Household row
+                /*
+                    Related Table rows deleted via cascading delete
+                    1) HouseholdUser
+                    2) ShoppingList
+                    3) Purchase
+                    4) ListItem
+                 */
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"

--- a/GroSharies/Repositories/IHouseholdRepository.cs
+++ b/GroSharies/Repositories/IHouseholdRepository.cs
@@ -10,5 +10,6 @@ namespace GroSharies.Repositories
         HouseholdDetail GetById(int householdId);
         void Add(Household household, int userId);
         void Update(Household household);
+        void Delete(int householdId, int shoppingListId);
     }
 }

--- a/GroSharies/Repositories/IHouseholdRepository.cs
+++ b/GroSharies/Repositories/IHouseholdRepository.cs
@@ -10,6 +10,6 @@ namespace GroSharies.Repositories
         HouseholdDetail GetById(int householdId);
         void Add(Household household, int userId);
         void Update(Household household);
-        void Delete(int householdId, int shoppingListId);
+        void Delete(int householdId);
     }
 }

--- a/GroSharies/client/src/App.js
+++ b/GroSharies/client/src/App.js
@@ -10,12 +10,12 @@ function App() {
     return (
         <Router>
             <UserProvider>
-                <HouseholdProvider>
-                    <HouseholdUserProvider>
+                <HouseholdUserProvider>
+                    <HouseholdProvider>
                         <Header />
                         <ApplicationViews />
-                    </HouseholdUserProvider>
-                </HouseholdProvider>
+                    </HouseholdProvider>
+                </HouseholdUserProvider>
             </UserProvider>
         </Router>
     );

--- a/GroSharies/client/src/components/ApplicationViews.js
+++ b/GroSharies/client/src/components/ApplicationViews.js
@@ -52,4 +52,4 @@ export default function ApplicationViews() {
             </Switch>
         </main>
     );
-}
+};

--- a/GroSharies/client/src/components/Households/Household.js
+++ b/GroSharies/client/src/components/Households/Household.js
@@ -1,22 +1,32 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Card, CardHeader, Button } from "reactstrap";
 import { Link, useHistory } from "react-router-dom";
 import { FaRegEdit } from "react-icons/fa";
 import { FaTrashAlt } from "react-icons/fa";
+import { HouseholdContext } from "../../providers/HouseholdProvider";
 
 const Household = ({ household, userType, isAccepted }) => {
 
     const history = useHistory();
-    
+    const { deleteHousehold } = useContext(HouseholdContext);
+
     // Determines if the user is an Admin of the related household.
     // If they are, add an edit button to allow them to change its name.
     const checkIfAdmin = () => {
         if(userType === 1) {
             return (<>
                 <Button size="sm" onClick={() => history.push(`/household/edit/${household.id}`)}><FaRegEdit /></Button>
-                <Button size="sm" onClick={() => history.push(`/household/delete/${household.id}`)}><FaTrashAlt /></Button>
+                <Button size="sm" onClick={() => deleteWarning()}><FaTrashAlt /></Button>
             </>)  
-        }
+        };
+    };
+
+    const deleteWarning = () => {
+        const confirmBox = window.confirm(`Are you sure you wish to delete the ${household.name} household? This action is irreversable.`);
+        if (confirmBox){
+            console.log(`Deleting Household: ${household.name}`)
+            deleteHousehold(household.id);
+        };
     };
     
     return(

--- a/GroSharies/client/src/components/Households/HouseholdFormAdd.js
+++ b/GroSharies/client/src/components/Households/HouseholdFormAdd.js
@@ -7,14 +7,13 @@ const HouseholdFormAdd = () => {
     const { saveHousehold } = useContext(HouseholdContext);
     const [isLoading, setIsLoading] = useState(false);
     const [household, setHousehold] = useState({
-        id: 0,
         name: ""
     });
     
     // Handles updating the state of household as the user updates the form
-    const handleInput = event => {
+    const handleInput = e => {
         const newHousehold = { ...household };
-        newHousehold[event.target.id] = event.target.value;
+        newHousehold[e.target.id] = e.target.value;
         setHousehold(newHousehold);
     }
 
@@ -26,7 +25,6 @@ const HouseholdFormAdd = () => {
 
         // Save the household object to the database
         saveHousehold({
-            id: household.id,
             name: household.name
         })
         .then(() => history.push("/household"));

--- a/GroSharies/client/src/components/Households/HouseholdFormEdit.js
+++ b/GroSharies/client/src/components/Households/HouseholdFormEdit.js
@@ -19,9 +19,9 @@ const HouseholdFormEdit = () => {
     },[]);
     
     // Handles updating the state of household as the user updates the form
-    const handleInput = event => {
+    const handleInput = e => {
         const newHousehold = { ...household };
-        newHousehold[event.target.id] = event.target.value;
+        newHousehold[e.target.id] = e.target.value;
         setHousehold(newHousehold);
     }
 

--- a/GroSharies/client/src/providers/HouseholdProvider.js
+++ b/GroSharies/client/src/providers/HouseholdProvider.js
@@ -1,5 +1,6 @@
 import React, { useState, createContext, useContext } from "react";
 import { UserContext } from "./UserProvider";
+import { HouseholdUserContext } from "./HouseholdUserProvider";
 import "firebase/auth";
 
 export const HouseholdContext = createContext();
@@ -7,6 +8,7 @@ export const HouseholdContext = createContext();
 export function HouseholdProvider(props) {
     const [households, setHouseholds] = useState([]);
     const { getToken } = useContext(UserContext); 
+    const { getUserHouseholds } = useContext(HouseholdUserContext);
     const apiUrl = "/api/household";
 
     // Called to retrieve all households associated with the current user
@@ -61,6 +63,18 @@ export function HouseholdProvider(props) {
         }))
     };
 
+    // Called when a user requests to delete a household they are an admin of
+    const deleteHousehold = householdId => {
+        return getToken()
+        .then(token => fetch(`${apiUrl}/${householdId}`, {
+            method: "DELETE",
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        }))
+        .then(getUserHouseholds)
+    };
+
     return (
         <HouseholdContext.Provider
             value={{
@@ -68,7 +82,8 @@ export function HouseholdProvider(props) {
                 getAllHouseholds,
                 getHousehold,
                 saveHousehold,
-                updateHousehold
+                updateHousehold,
+                deleteHousehold
             }}
         >
             {props.children}


### PR DESCRIPTION
## Changes
1. Updated Database Creation Query to include a cascading delete feature for all tables that are children of another table
 (e.g. if a Household is deleted, all associated HouseholdUser, ShoppingList, Purchase, and ListItem rows are deleted along with it.)
2. An user can now delete a Household from the Household List Page if they created it (In other words, they are the admin).